### PR TITLE
Fix number size on Ecommerce Statistics

### DIFF
--- a/src/OroCRM/Bundle/MagentoBundle/Resources/views/Dashboard/bigNumberSubwidget.html.twig
+++ b/src/OroCRM/Bundle/MagentoBundle/Resources/views/Dashboard/bigNumberSubwidget.html.twig
@@ -1,5 +1,5 @@
 <span class="title">{{ item.label|trans }}</span>
-<h2 class="value">{{ item.value.value|raw }}</h2>
+<h3 class="value">{{ item.value.value|raw }}</h3>
 {% if item.value.deviation is defined %}
 <div class="deviation">
     <span class="deviation {% if item.value.isPositive is defined %}{% if item.value.isPositive %}positive{% else %}negative{% endif %}{% endif %}">


### PR DESCRIPTION
Simple fix to avoid the behavior described on the image bellow:

![Ecommerce Big Numbers widget](http://s12.postimg.org/bq2qy8rwt/Screen_Shot_2015_07_10_at_9_55_10_AM.png)