### PR TITLE
Move average_lifetime_sales_chart to the `SalesBundle`

### DIFF
--- a/src/OroCRM/Bundle/ChannelBundle/Resources/config/dashboard.yml
+++ b/src/OroCRM/Bundle/ChannelBundle/Resources/config/dashboard.yml
@@ -2,18 +2,3 @@ oro_dashboard_config:
     dashboards:
         e_commerce:
             twig: OroDashboardBundle:Index:default.html.twig
-
-    widgets:
-        average_lifetime_sales_chart:
-            label:       orocrm.channel.dashboard.average_lifetime_sales_chart.title
-            route:       orocrm_channel_dashboard_average_lifetime_sales_chart
-            acl:         orocrm_channel_view
-            description: orocrm.channel.dashboard.average_lifetime_sales_chart.description
-            icon:        bundles/orocrmchannel/img/average_lifetime_sales_chart.png
-            applicable:  @orocrm_sales.provider.enitity_state->isEntityOpportunityEnabled()
-            configuration:
-                dateRange:
-                    type: oro_type_widget_date_range
-                    options:
-                        label: oro.dashboard.date_range.label
-                    show_on_widget: true

--- a/src/OroCRM/Bundle/SalesBundle/Resources/config/dashboard.yml
+++ b/src/OroCRM/Bundle/SalesBundle/Resources/config/dashboard.yml
@@ -205,3 +205,16 @@ oro_dashboard_config:
                        item_label: oro.dashboard.widget.big_number.metricName
                        required: false
                        widget_name: b2b_statistics_widget
+        average_lifetime_sales_chart:
+            label:       orocrm.channel.dashboard.average_lifetime_sales_chart.title
+            route:       orocrm_channel_dashboard_average_lifetime_sales_chart
+            acl:         orocrm_channel_view
+            description: orocrm.channel.dashboard.average_lifetime_sales_chart.description
+            icon:        bundles/orocrmchannel/img/average_lifetime_sales_chart.png
+            applicable:  @orocrm_sales.provider.enitity_state->isEntityOpportunityEnabled()
+            configuration:
+                dateRange:
+                    type: oro_type_widget_date_range
+                    options:
+                        label: oro.dashboard.date_range.label
+                    show_on_widget: true


### PR DESCRIPTION
Hi all,

I tried to move our app from `platform-application` to `crm-application`, because we need more and more stuff from there. But we also want to exclude things like the `SalesBundle`.

But I face an error, when doing so: `You have requested a non-existent service "orocrm_sales.provider.enitity_state".` You find it in the `ChannelBundle` dashboard config.

In my opinion, the lifetime sales dashboard is a dashboard made for sales and not for channel. It's based on channels, yes, but it doesn't make sense without the `SalesBundle`.