### PR TITLE
Fixed lead phone number migration

### DIFF
--- a/src/OroCRM/Bundle/SalesBundle/Migrations/Schema/v1_24/ConvertPhoneNumberInPhone.php
+++ b/src/OroCRM/Bundle/SalesBundle/Migrations/Schema/v1_24/ConvertPhoneNumberInPhone.php
@@ -31,7 +31,7 @@ class ConvertPhoneNumberInPhone implements
     public function up(Schema $schema, QueryBag $queries)
     {
         $query  = 'INSERT INTO orocrm_sales_lead_phone (owner_id, phone, is_primary)
-                       SELECT orocrm_sales_lead.id, orocrm_sales_lead.phone_number, \'1\' FROM orocrm_sales_lead';
+                       SELECT orocrm_sales_lead.id, orocrm_sales_lead.phone_number, \'1\' FROM orocrm_sales_lead WHERE orocrm_sales_lead.phone_number IS NOT NULL';
 
         $queries->addPostQuery($query);
     }


### PR DESCRIPTION
The column `orocrm_sales_lead.phone_number` is nullable, the query must filter null values otherwise it will try to add a null value to `orocrm_sales_lead_phone.phone`, whose does not accept null values.