### PR TITLE
Fixed OroCRMCallBridgeBundle Migration

### DIFF
--- a/src/Oro/CRMCallBridgeBundle/Migrations/Schema/v1_0/OroCRMCallBridgeBundle.php
+++ b/src/Oro/CRMCallBridgeBundle/Migrations/Schema/v1_0/OroCRMCallBridgeBundle.php
@@ -46,6 +46,10 @@ class OroCRMCallBridgeBundle implements Migration, ActivityExtensionAwareInterfa
         ];
 
         foreach ($associationTables as $tableName) {
+            if (!$schema->hasTable($tableName)) {
+                continue;
+            }
+
             $associationTableName = $activityExtension->getAssociationTableName('orocrm_call', $tableName);
             if (!$schema->hasTable($associationTableName)) {
                 $activityExtension->addActivityAssociation($schema, 'orocrm_call', $tableName);


### PR DESCRIPTION
The migration no longer tries to install the activity relation for
tables which are not loadad (do not exist).

Closes #213

PS: I based the PR on 1.10 branch because the class is not present in master. 