### PR TITLE
Fixed OroCRMTaskBundle Migration

### DIFF
--- a/src/Oro/CRMTaskBundle/Migrations/Schema/v1_0/OroCRMTaskBundle.php
+++ b/src/Oro/CRMTaskBundle/Migrations/Schema/v1_0/OroCRMTaskBundle.php
@@ -52,6 +52,10 @@ class OroCRMTaskBundle implements
             'orocrm_magento_order'
         ];
         foreach ($targetTables as $targetTable) {
+            if (!$schema->hasTable($targetTable)) {
+                continue;
+            }
+
             $associationTableName = $activityExtension->getAssociationTableName('orocrm_task', $targetTable);
             if (!$schema->hasTable($associationTableName)) {
                 $activityExtension->addActivityAssociation($schema, 'orocrm_task', $targetTable);


### PR DESCRIPTION
The migration no longer tries to install the activity relation for
tables which are not loadad (do not exist).

Closes #211